### PR TITLE
Add rule for default gflag DEFINE

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -195,6 +195,7 @@ _ERROR_CATEGORIES = [
     'build/namespaces',
     'build/printf_format',
     'build/storage_class',
+    'build/gflag_default_api',
     'legal/copyright',
     'readability/alt_tokens',
     'readability/braces',
@@ -5700,6 +5701,29 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
             'Add #include ' + required_header_unstripped + ' for ' + template)
 
 
+_RE_PATTERN_GFLAG_DEFAULT_API = re.compile(r'DEFINE_(bool|int32|int64|uint64|double|string)')
+
+
+def CheckGflagDefaultApiCheckMakePairUsesDeduction(filename, clean_lines, linenum, error):
+  """Check if we're still using the default gflag DEFINE flag api.
+
+  We've added a new set of APIs for runtime vs non-runtime flags in D19978, which should be used by
+  default, moving forward.
+
+  Args:
+    filename: The name of the current file.
+    clean_lines: A CleansedLines instance containing the file.
+    linenum: The number of the line to check.
+    error: The function to call with any errors found.
+  """
+  line = clean_lines.elided[linenum]
+  match = _RE_PATTERN_GFLAG_DEFAULT_API.search(line)
+  if match:
+    error(filename, linenum, 'build/gflag_default_api',
+          4,  # 4 = high confidence
+          'Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.')
+
+
 _RE_PATTERN_EXPLICIT_MAKEPAIR = re.compile(r'\bmake_pair\s*<')
 
 
@@ -5923,6 +5947,7 @@ def ProcessLine(filename, file_extension, clean_lines, line,
   CheckPosixThreading(filename, clean_lines, line, error)
   CheckInvalidIncrement(filename, clean_lines, line, error)
   CheckMakePairUsesDeduction(filename, clean_lines, line, error)
+  CheckGflagDefaultApiCheckMakePairUsesDeduction(filename, clean_lines, line, error)
   CheckRedundantVirtual(filename, clean_lines, line, error)
   CheckRedundantOverrideOrFinal(filename, clean_lines, line, error)
   for check_fn in extra_check_functions:


### PR DESCRIPTION
Adding a rule to throw warnings on new code adding gflags via the original gflag API.

Validated all rules by making a simple change to the YB repo, adding all types of flags we support
```
diff --git a/src/yb/master/master_main.cc b/src/yb/master/master_main.cc
index 3d0a2a2..b59c993 100644
--- a/src/yb/master/master_main.cc
+++ b/src/yb/master/master_main.cc
@@ -74,6 +74,13 @@ DECLARE_bool(use_docdb_aware_bloom_filter);
 DECLARE_int32(follower_unavailable_considered_failed_sec);
 DECLARE_int32(log_min_seconds_to_retain);

+DEFINE_bool(bogdan_bool, 0, "testing");
+DEFINE_int32(bogdan_int32, 0, "testing");
+DEFINE_int64(bogdan_int64, 0, "testing");
+DEFINE_uint64(bogdan_uint64, 0, "testing");
+DEFINE_double(bogdan_double, 0, "testing");
+DEFINE_string(bogdan_string, "", "testing");
+
 using namespace std::literals;

 namespace yb {
```

Confirmed lint warnings for all of them as expected
```
>>> Lint for src/yb/master/master_main.cc:


   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              74 DECLARE_int32(follower_unavailable_considered_failed_sec);
              75 DECLARE_int32(log_min_seconds_to_retain);
              76
    >>>       77 DEFINE_bool(bogdan_bool, 0, "testing");
              78 DEFINE_int32(bogdan_int32, 0, "testing");
              79 DEFINE_int64(bogdan_int64, 0, "testing");
              80 DEFINE_uint64(bogdan_uint64, 0, "testing");

   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              75 DECLARE_int32(log_min_seconds_to_retain);
              76
              77 DEFINE_bool(bogdan_bool, 0, "testing");
    >>>       78 DEFINE_int32(bogdan_int32, 0, "testing");
              79 DEFINE_int64(bogdan_int64, 0, "testing");
              80 DEFINE_uint64(bogdan_uint64, 0, "testing");
              81 DEFINE_double(bogdan_double, 0, "testing");

   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              76
              77 DEFINE_bool(bogdan_bool, 0, "testing");
              78 DEFINE_int32(bogdan_int32, 0, "testing");
    >>>       79 DEFINE_int64(bogdan_int64, 0, "testing");
              80 DEFINE_uint64(bogdan_uint64, 0, "testing");
              81 DEFINE_double(bogdan_double, 0, "testing");
              82 DEFINE_string(bogdan_string, "", "testing");

   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              77 DEFINE_bool(bogdan_bool, 0, "testing");
              78 DEFINE_int32(bogdan_int32, 0, "testing");
              79 DEFINE_int64(bogdan_int64, 0, "testing");
    >>>       80 DEFINE_uint64(bogdan_uint64, 0, "testing");
              81 DEFINE_double(bogdan_double, 0, "testing");
              82 DEFINE_string(bogdan_string, "", "testing");
              83

   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              78 DEFINE_int32(bogdan_int32, 0, "testing");
              79 DEFINE_int64(bogdan_int64, 0, "testing");
              80 DEFINE_uint64(bogdan_uint64, 0, "testing");
    >>>       81 DEFINE_double(bogdan_double, 0, "testing");
              82 DEFINE_string(bogdan_string, "", "testing");
              83
              84 using namespace std::literals;

   Error  (build/gflag_default_api) build/gflag_default_api
    Please use the new DEFINE_RUNTIME and DEFINE_NON_RUNTIME macros.

              79 DEFINE_int64(bogdan_int64, 0, "testing");
              80 DEFINE_uint64(bogdan_uint64, 0, "testing");
              81 DEFINE_double(bogdan_double, 0, "testing");
    >>>       82 DEFINE_string(bogdan_string, "", "testing");
              83
              84 using namespace std::literals;
              85