### PR TITLE
Prevent DEFINE_uint32

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5702,7 +5702,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
             'Add #include ' + required_header_unstripped + ' for ' + template)
 
 
-_RE_PATTERN_GFLAG_DEFAULT_API = re.compile(r'DEFINE_(bool|int32|int64|uint64|double|string)')
+_RE_PATTERN_GFLAG_DEFAULT_API = re.compile(r'DEFINE_(bool|int32|u?int64|double|string)')
 
 
 def CheckGflagDefaultApi(filename, clean_lines, linenum, error):

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -5702,7 +5702,7 @@ def CheckForIncludeWhatYouUse(filename, clean_lines, include_state, error,
             'Add #include ' + required_header_unstripped + ' for ' + template)
 
 
-_RE_PATTERN_GFLAG_DEFAULT_API = re.compile(r'DEFINE_(bool|int32|u?int64|double|string)')
+_RE_PATTERN_GFLAG_DEFAULT_API = re.compile(r'DEFINE_(bool|u?int32|u?int64|double|string)')
 
 
 def CheckGflagDefaultApi(filename, clean_lines, linenum, error):


### PR DESCRIPTION
Similar to commit 67852d898b5f924060a2e5d8bb62ba77310b98b6

    Add rule to prevent original gflag DEFINE apis (#6)

prevent DEFINE_uint32 in favor of DEFINE_RUNTIME_uint32 and
DEFINE_NON_RUNTIME_uint32.