### PR TITLE
Use YugabyteDB as the copyright name

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1756,7 +1756,7 @@ def CheckForCopyright(filename, lines, error):
 
   # We'll say it should occur by line 10. Don't forget there's a
   # dummy line at the front.
-  YUGABYTE_COPYRIGHT = "// Copyright (c) Yugabyte, Inc."
+  YUGABYTE_COPYRIGHT = "// Copyright (c) YugabyteDB, Inc."
   ALLOWED_COPYRIGHT_LINES = [YUGABYTE_COPYRIGHT,
                              "// Copyright (c) YugaByte, Inc.",
                              "// Portions Copyright (c) YugaByte, Inc.",

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1762,6 +1762,7 @@ def CheckForCopyright(filename, lines, error):
                              "// Copyright (c) Yugabyte, Inc.",
                              "// Portions Copyright (c) YugaByte, Inc.",
                              "// Portions Copyright (c) Yugabyte, Inc.",
+                             "// Portions Copyright (c) YugabyteDB, Inc.",
                              "// regarding copyright ownership. The ASF licenses this file",
                              "// Copyright (c) 20XX The Chromium Authors. All rights reserved",
                              "// Copyright (c) 20XX The LevelDB Authors. All rights reserved",

--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -1759,6 +1759,7 @@ def CheckForCopyright(filename, lines, error):
   YUGABYTE_COPYRIGHT = "// Copyright (c) YugabyteDB, Inc."
   ALLOWED_COPYRIGHT_LINES = [YUGABYTE_COPYRIGHT,
                              "// Copyright (c) YugaByte, Inc.",
+                             "// Copyright (c) Yugabyte, Inc.",
                              "// Portions Copyright (c) YugaByte, Inc.",
                              "// Portions Copyright (c) Yugabyte, Inc.",
                              "// regarding copyright ownership. The ASF licenses this file",


### PR DESCRIPTION
Using the corporate name (YugabyteDB, Inc) in the `yb-cpplint`.