### PR TITLE
Remove a bad whitespace/todo rule

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -3187,12 +3187,6 @@ def CheckComment(line, filename, linenum, next_line_start, error):
       comment = line[commentpos:]
       match = _RE_PATTERN_TODO.match(comment)
       if match:
-        # One whitespace is correct; zero whitespace is handled elsewhere.
-        leading_whitespace = match.group(1)
-        if len(leading_whitespace) > 1:
-          error(filename, linenum, 'whitespace/todo', 2,
-                'Too many spaces before TODO')
-
         username = match.group(2)
         if not username:
           error(filename, linenum, 'readability/todo', 2,


### PR DESCRIPTION
There are two lint checks that map to the category whitespace/todo.  One
of them checks that there is not more than one space between "//" and
"TODO".  For example, the following fails

    // Fruits:
    // - Apple: ...
    //   ...
    //   ...
    // - Pear: ...
    //   ...
    //   TODO...

Given the above legitimate case, this check has some false positives, so
get rid of it entirely.  There is still the other check mapping to
whitespace/todo that remains valid.