### PR TITLE
Add exception to readability/braces for concepts

### DIFF
--- a/cpplint/cpplint.py
+++ b/cpplint/cpplint.py
@@ -4009,6 +4009,7 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
     #  - Lambdas
     #  - alignas specifier with anonymous structs
     #  - decltype
+    #  - requires
     closing_brace_pos = match.group(1).rfind(')')
     opening_parenthesis = ReverseCloseExpression(
         clean_lines, linenum, closing_brace_pos)
@@ -4026,6 +4027,12 @@ def CheckTrailingSemicolon(filename, clean_lines, linenum, error):
           Search(r'\bdecltype$', line_prefix) or
           Search(r'\s+=\s*$', line_prefix)):
         match = None
+
+    if match:
+        keyword = Search(r'\b([a-z]+)\s*$', line_prefix)
+        if keyword and keyword.group(1) in ('requires',):
+          match = None
+
     if (match and
         opening_parenthesis[1] > 1 and
         Search(r'\]\s*$', clean_lines.elided[opening_parenthesis[1] - 1])):


### PR DESCRIPTION
Defining a concept as below can lead to readability/braces errors:
```
template<typename T>
concept TestConcept = requires(T value) {
   // ...
};
```
due to the semicolon at the end. This semicolon is required, and we use
`// NOLINT` at every place where this matches.

This adds an exception to the readability/braces for this case.